### PR TITLE
feat(completions): add intelligent shell tab completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0da80818b2d95eca9aa614a30783e42f62bf5fdfee24e68cfb960b071ba8d1"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +909,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1049,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "clap_complete",
  "color-eyre",
  "crossterm",
  "dialoguer",
@@ -1040,6 +1062,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 chrono = { version = "0.4.42", features = ["clock"] }
 clap = { version = "4.5.51", features = ["derive"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 color-eyre = "0.6"
 crossterm = "0.28"
 dialoguer = "0.11"
@@ -26,6 +27,7 @@ regex = "1.12.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+walkdir = "2.5"
 
 [dev-dependencies]
 assert_cmd = "2.1.1"

--- a/crates/cli/src/completions.rs
+++ b/crates/cli/src/completions.rs
@@ -1,0 +1,165 @@
+//! Shell completion support with dynamic value completers.
+//!
+//! This module provides intelligent tab completions that understand the user's vault
+//! configuration, offering context-aware suggestions for types, templates, captures, etc.
+
+use clap_complete::engine::CompletionCandidate;
+use mdvault_core::captures::CaptureRepository;
+use mdvault_core::config::loader::ConfigLoader;
+use mdvault_core::macros::MacroRepository;
+use mdvault_core::templates::repository::TemplateRepository;
+use mdvault_core::types::{TypeRegistry, TypedefRepository};
+use std::ffi::OsStr;
+
+/// Load the resolved config, returning None if it fails.
+fn load_config() -> Option<mdvault_core::config::types::ResolvedConfig> {
+    ConfigLoader::load(None, None).ok()
+}
+
+/// Complete note types (built-in + custom from TypeRegistry).
+pub fn complete_types(current: &OsStr) -> Vec<CompletionCandidate> {
+    let mut completions = vec![];
+    let current_str = current.to_str().unwrap_or("");
+
+    // Built-in types are always available
+    let builtin_types = [
+        ("daily", "Daily journal notes"),
+        ("weekly", "Weekly overview notes"),
+        ("task", "Individual actionable tasks"),
+        ("project", "Collections of related tasks"),
+        ("zettel", "Knowledge notes (Zettelkasten-style)"),
+    ];
+
+    for (name, help) in builtin_types {
+        if name.starts_with(current_str) {
+            completions.push(CompletionCandidate::new(name).help(Some(help.into())));
+        }
+    }
+
+    // Try to load custom types from config
+    if let Some(cfg) = load_config() {
+        if let Ok(typedef_repo) = TypedefRepository::new(&cfg.typedefs_dir) {
+            if let Ok(registry) = TypeRegistry::from_repository(&typedef_repo) {
+                for type_name in registry.list_custom_types() {
+                    if type_name.starts_with(current_str) {
+                        completions.push(
+                            CompletionCandidate::new(type_name)
+                                .help(Some("Custom type".into())),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    completions
+}
+
+/// Complete template names from TemplateRepository.
+pub fn complete_templates(current: &OsStr) -> Vec<CompletionCandidate> {
+    let mut completions = vec![];
+    let current_str = current.to_str().unwrap_or("");
+
+    if let Some(cfg) = load_config() {
+        if let Ok(repo) = TemplateRepository::new(&cfg.templates_dir) {
+            for info in repo.list_all() {
+                if info.logical_name.starts_with(current_str) {
+                    completions.push(CompletionCandidate::new(&info.logical_name));
+                }
+            }
+        }
+    }
+
+    completions
+}
+
+/// Complete capture names from CaptureRepository.
+pub fn complete_captures(current: &OsStr) -> Vec<CompletionCandidate> {
+    let mut completions = vec![];
+    let current_str = current.to_str().unwrap_or("");
+
+    if let Some(cfg) = load_config() {
+        if let Ok(repo) = CaptureRepository::new(&cfg.captures_dir) {
+            for info in repo.list_all() {
+                if info.logical_name.starts_with(current_str) {
+                    completions.push(CompletionCandidate::new(&info.logical_name));
+                }
+            }
+        }
+    }
+
+    completions
+}
+
+/// Complete macro names from MacroRepository.
+pub fn complete_macros(current: &OsStr) -> Vec<CompletionCandidate> {
+    let mut completions = vec![];
+    let current_str = current.to_str().unwrap_or("");
+
+    if let Some(cfg) = load_config() {
+        if let Ok(repo) = MacroRepository::new(&cfg.macros_dir) {
+            for info in repo.list_all() {
+                if info.logical_name.starts_with(current_str) {
+                    completions.push(CompletionCandidate::new(&info.logical_name));
+                }
+            }
+        }
+    }
+
+    completions
+}
+
+/// Complete note paths from the vault.
+/// This walks the vault directory and returns markdown files.
+pub fn complete_notes(current: &OsStr) -> Vec<CompletionCandidate> {
+    let mut completions = vec![];
+    let current_str = current.to_str().unwrap_or("");
+
+    if let Some(cfg) = load_config() {
+        // Walk and collect note paths relative to vault root
+        for entry in walkdir::WalkDir::new(&cfg.vault_root)
+            .min_depth(1)
+            .max_depth(5) // Limit depth for performance
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map(|ext| ext == "md").unwrap_or(false))
+            .take(100)
+        // Limit results for performance
+        {
+            if let Ok(rel_path) = entry.path().strip_prefix(&cfg.vault_root) {
+                let path_str = rel_path.to_string_lossy();
+                if path_str.starts_with(current_str) {
+                    completions.push(CompletionCandidate::new(path_str.to_string()));
+                }
+            }
+        }
+    }
+
+    completions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_complete_types_builtin() {
+        let completions = complete_types(OsStr::new(""));
+        let names: Vec<_> =
+            completions.iter().map(|c| c.get_value().to_str().unwrap()).collect();
+
+        assert!(names.contains(&"daily"));
+        assert!(names.contains(&"task"));
+        assert!(names.contains(&"project"));
+    }
+
+    #[test]
+    fn test_complete_types_prefix_filter() {
+        let completions = complete_types(OsStr::new("da"));
+        let names: Vec<_> =
+            completions.iter().map(|c| c.get_value().to_str().unwrap()).collect();
+
+        assert!(names.contains(&"daily"));
+        assert!(!names.contains(&"task"));
+    }
+}


### PR DESCRIPTION
## Summary
- Implement dynamic shell completions using clap_complete v4.5+ Custom Completers
- Add completers for types (built-in + custom from TypeRegistry), templates, captures, macros, and note paths
- Add `completions` subcommand to generate shell scripts (bash, zsh, fish, elvish, powershell)
- Wire up `ArgValueCompleter` to relevant CLI arguments for context-aware suggestions

## Usage

### Generate static completion scripts
```bash
# For zsh (add to ~/.zshrc)
mdv completions zsh > ~/.zsh/completions/_mdv

# For bash (add to ~/.bashrc)  
mdv completions bash > ~/.bash_completion.d/mdv

# For fish
mdv completions fish > ~/.config/fish/completions/mdv.fish
```

### Enable dynamic completions (recommended)
Add to shell rc file:
```bash
# For bash
source <(COMPLETE=bash mdv)

# For zsh
source <(COMPLETE=zsh mdv)

# For fish
COMPLETE=fish mdv | source
```

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` passes
- [x] `mdv completions zsh` generates valid shell script
- [x] CLI commands still work correctly

Closes #67