### PR TITLE
refactor: Phase 4 cleanup, dead code removal, edition alignment (MDV-053)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "mdvault"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "assert_cmd",
  "charts-rs",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "mdvault-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "comrak",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdvault"
 version = "0.7.1"
-edition = "2021"
+edition = "2024"
 description = "CLI tool for managing markdown vaults with structured notes, validation, and search"
 license = "MIT"
 repository = "https://github.com/agustinvalencia/mdvault"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdvault"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "CLI tool for managing markdown vaults with structured notes, validation, and search"
 license = "MIT"
@@ -22,7 +22,7 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 color-eyre = "0.6"
 crossterm = "0.29"
 dialoguer = { version = "0.12", features = ["fuzzy-select"] }
-mdvault-core = { version = "0.7.1", path = "../core" }
+mdvault-core = { version = "0.7.2", path = "../core" }
 ratatui = "0.30"
 regex = "1.12.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/cli/src/args/note.rs
+++ b/crates/cli/src/args/note.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use clap_complete::engine::ArgValueCompleter;
 use std::path::PathBuf;
 
-use super::{parse_key_val, NoteTypeArg, OutputFormat};
+use super::{NoteTypeArg, OutputFormat, parse_key_val};
 
 #[derive(Debug, Args)]
 #[command(after_help = "\

--- a/crates/cli/src/cmd/area.rs
+++ b/crates/cli/src/cmd/area.rs
@@ -1,11 +1,11 @@
 //! Area management commands.
 
 use chrono::{Datelike, Local, NaiveDate};
-use color_eyre::eyre::{bail, Result};
+use color_eyre::eyre::{Result, bail};
 use mdvault_core::index::{IndexedNote, NoteQuery, NoteType};
 use serde::Serialize;
 use std::path::Path;
-use tabled::{settings::Style, Table, Tabled};
+use tabled::{Table, Tabled, settings::Style};
 
 use super::common::{load_config, open_index};
 
@@ -378,11 +378,7 @@ pub fn export(
         .iter()
         .filter_map(|n| {
             let date = get_note_date(n)?;
-            if date >= start && date <= end {
-                Some((n, date))
-            } else {
-                None
-            }
+            if date >= start && date <= end { Some((n, date)) } else { None }
         })
         .collect();
     daily_in_range.sort_by_key(|(_, d)| *d);

--- a/crates/cli/src/cmd/capture.rs
+++ b/crates/cli/src/cmd/capture.rs
@@ -3,14 +3,14 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use color_eyre::eyre::{bail, Result, WrapErr};
+use color_eyre::eyre::{Result, WrapErr, bail};
 
 use super::common::load_config;
-use crate::prompt::{collect_variables, create_fuzzy_selector_callback, PromptOptions};
+use crate::prompt::{PromptOptions, collect_variables, create_fuzzy_selector_callback};
 use mdvault_core::activity::ActivityLogService;
 use mdvault_core::captures::{
-    run_after_insert_hook, run_before_insert_hook, CaptureRepoError, CaptureRepository,
-    CaptureSpec,
+    CaptureRepoError, CaptureRepository, CaptureSpec, run_after_insert_hook,
+    run_before_insert_hook,
 };
 use mdvault_core::config::types::ResolvedConfig;
 use mdvault_core::domain::services::set_updated_at;
@@ -19,7 +19,7 @@ use mdvault_core::index::{IndexBuilder, IndexDb};
 use mdvault_core::macros::MacroRepository;
 use mdvault_core::markdown_ast::{MarkdownAstError, MarkdownEditor, SectionMatch};
 use mdvault_core::paths::PathResolver;
-use mdvault_core::scripting::{run_on_update_hook, NoteContext, VaultContext};
+use mdvault_core::scripting::{NoteContext, VaultContext, run_on_update_hook};
 use mdvault_core::templates::engine::render_string as engine_render_string;
 use mdvault_core::templates::repository::TemplateRepository;
 use mdvault_core::types::{TypeRegistry, TypedefRepository};
@@ -509,11 +509,7 @@ fn render_string(template: &str, ctx: &HashMap<String, String>) -> String {
 
 fn resolve_target_path(vault_root: &Path, target: &str) -> std::path::PathBuf {
     let path = std::path::Path::new(target);
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        vault_root.join(path)
-    }
+    if path.is_absolute() { path.to_path_buf() } else { vault_root.join(path) }
 }
 
 /// Create a minimal note structure for auto-created files.

--- a/crates/cli/src/cmd/charts.rs
+++ b/crates/cli/src/cmd/charts.rs
@@ -4,8 +4,8 @@
 //! PNG images suitable for embedding in markdown notes.
 
 use charts_rs::{
-    svg_to_png, BarChart, ChildChart, LineChart, MultiChart, PieChart, Series,
-    THEME_GRAFANA,
+    BarChart, ChildChart, LineChart, MultiChart, PieChart, Series, THEME_GRAFANA,
+    svg_to_png,
 };
 use mdvault_core::report::{DashboardReport, ProjectReport};
 use std::path::Path;

--- a/crates/cli/src/cmd/check.rs
+++ b/crates/cli/src/cmd/check.rs
@@ -3,8 +3,8 @@
 use std::path::Path;
 
 use super::common::{load_config, open_index};
-use color_eyre::eyre::{bail, Result};
-use mdvault_core::lint::{run_lint, CategoryReport, LintReport};
+use color_eyre::eyre::{Result, bail};
+use mdvault_core::lint::{CategoryReport, LintReport, run_lint};
 use mdvault_core::types::{TypeRegistry, TypedefRepository};
 
 use crate::CheckArgs;

--- a/crates/cli/src/cmd/context.rs
+++ b/crates/cli/src/cmd/context.rs
@@ -6,7 +6,7 @@ use super::common::load_config;
 use chrono::{Datelike, Duration, Local, NaiveDate};
 use color_eyre::eyre::{Result, WrapErr};
 use mdvault_core::context::ContextQueryService;
-use mdvault_core::vars::datemath::{parse_date_expr, DateBase};
+use mdvault_core::vars::datemath::{DateBase, parse_date_expr};
 
 /// Get context for a specific day.
 pub fn day(
@@ -233,10 +233,10 @@ fn find_last_active_day(
 ) -> Option<mdvault_core::context::DayContext> {
     for i in 1..=30 {
         let date = start_date - Duration::days(i);
-        if let Ok(ctx) = service.day_context(date) {
-            if !is_empty_context(&ctx) {
-                return Some(ctx);
-            }
+        if let Ok(ctx) = service.day_context(date)
+            && !is_empty_context(&ctx)
+        {
+            return Some(ctx);
         }
     }
     None

--- a/crates/cli/src/cmd/doctor.rs
+++ b/crates/cli/src/cmd/doctor.rs
@@ -1,5 +1,5 @@
-use color_eyre::eyre::{bail, Result};
-use mdvault_core::config::loader::{default_config_path, ConfigLoader};
+use color_eyre::eyre::{Result, bail};
+use mdvault_core::config::loader::{ConfigLoader, default_config_path};
 use std::path::Path;
 
 pub fn run(config: Option<&Path>, profile: Option<&str>) -> Result<()> {

--- a/crates/cli/src/cmd/focus.rs
+++ b/crates/cli/src/cmd/focus.rs
@@ -29,10 +29,10 @@ pub fn run(
         manager.clear_focus().wrap_err("Failed to clear focus")?;
 
         // Log to activity log
-        if let Some(activity) = ActivityLogService::try_from_config(&cfg) {
-            if let Some(ref project) = prev_project {
-                let _ = activity.log_focus(project, None, "clear");
-            }
+        if let Some(activity) = ActivityLogService::try_from_config(&cfg)
+            && let Some(ref project) = prev_project
+        {
+            let _ = activity.log_focus(project, None, "clear");
         }
 
         println!("Focus cleared.");

--- a/crates/cli/src/cmd/links.rs
+++ b/crates/cli/src/cmd/links.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::common::{load_config, open_index};
 use super::output::{
-    print_links_json, print_links_quiet, print_links_table, resolve_format, LinkOutput,
+    LinkOutput, print_links_json, print_links_quiet, print_links_table, resolve_format,
 };
 use crate::{LinksArgs, OutputFormat};
 use color_eyre::eyre::{Result, WrapErr};

--- a/crates/cli/src/cmd/list.rs
+++ b/crates/cli/src/cmd/list.rs
@@ -48,11 +48,11 @@ fn parse_date_arg(arg: &Option<String>, name: &str) -> Option<DateTime<Utc>> {
     let s = arg.as_ref()?;
 
     // Try date math expression first (e.g., "today - 7d")
-    if let Some(result) = try_evaluate_date_expr(s) {
-        if let Ok(date) = NaiveDate::parse_from_str(&result, "%Y-%m-%d") {
-            let datetime = date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
-            return Some(DateTime::from_naive_utc_and_offset(datetime, Utc));
-        }
+    if let Some(result) = try_evaluate_date_expr(s)
+        && let Ok(date) = NaiveDate::parse_from_str(&result, "%Y-%m-%d")
+    {
+        let datetime = date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+        return Some(DateTime::from_naive_utc_and_offset(datetime, Utc));
     }
 
     // Try ISO date (YYYY-MM-DD)

--- a/crates/cli/src/cmd/macro_cmd.rs
+++ b/crates/cli/src/cmd/macro_cmd.rs
@@ -5,18 +5,18 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use color_eyre::eyre::{bail, Result, WrapErr};
+use color_eyre::eyre::{Result, WrapErr, bail};
 
 use super::common::load_config;
-use crate::prompt::{collect_variables, PromptOptions};
+use crate::prompt::{PromptOptions, collect_variables};
 use mdvault_core::captures::CaptureRepository;
 use mdvault_core::config::types::ResolvedConfig;
 use mdvault_core::frontmatter::{apply_ops, parse, serialize};
 use mdvault_core::index::{IndexBuilder, IndexDb};
 use mdvault_core::macros::{
-    get_shell_commands, requires_trust, run_macro, CaptureStep, MacroRepoError,
-    MacroRepository, MacroRunError, MacroSpec, RunContext, RunOptions, ShellStep,
-    StepExecutor, StepResult, TemplateStep,
+    CaptureStep, MacroRepoError, MacroRepository, MacroRunError, MacroSpec, RunContext,
+    RunOptions, ShellStep, StepExecutor, StepResult, TemplateStep, get_shell_commands,
+    requires_trust, run_macro,
 };
 use mdvault_core::markdown_ast::{MarkdownEditor, SectionMatch};
 use mdvault_core::paths::PathResolver;

--- a/crates/cli/src/cmd/new/discovery.rs
+++ b/crates/cli/src/cmd/new/discovery.rs
@@ -1,9 +1,9 @@
-use color_eyre::eyre::{bail, Result, WrapErr};
+use color_eyre::eyre::{Result, WrapErr, bail};
 
 use mdvault_core::config::types::ResolvedConfig;
 use mdvault_core::frontmatter::parse as parse_frontmatter;
 use mdvault_core::templates::engine::{render_string, resolve_template_output_path};
-use mdvault_core::types::{discovery::load_typedef_from_file, TypeDefinition};
+use mdvault_core::types::{TypeDefinition, discovery::load_typedef_from_file};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -24,8 +24,8 @@ pub(super) fn resolve_lua_output(
     cfg: &ResolvedConfig,
     render_ctx: &HashMap<String, String>,
 ) -> Result<PathBuf> {
-    if let Some(ref typedef) = lua_typedef {
-        if let Some(ref output_template) = typedef.output {
+    if let Some(typedef) = lua_typedef {
+        if let Some(output_template) = &typedef.output {
             render_output_path(output_template, cfg, render_ctx)
                 .wrap_err("Failed to resolve Lua output path")
         } else {
@@ -58,7 +58,7 @@ pub(super) fn resolve_output_path(
                     match nt.behavior().output_path(ctx) {
                         Ok(path) => return Ok(path),
                         Err(_) => {
-                            return resolve_lua_output(lua_typedef, cfg, render_ctx)
+                            return resolve_lua_output(lua_typedef, cfg, render_ctx);
                         }
                     }
                 } else {
@@ -119,11 +119,7 @@ fn render_output_path(
         render_string(template, ctx).wrap_err("Failed to render output path template")?;
 
     let path = PathBuf::from(&rendered);
-    if path.is_absolute() {
-        Ok(path)
-    } else {
-        Ok(cfg.vault_root.join(path))
-    }
+    if path.is_absolute() { Ok(path) } else { Ok(cfg.vault_root.join(path)) }
 }
 
 #[cfg(test)]

--- a/crates/cli/src/cmd/new/hooks.rs
+++ b/crates/cli/src/cmd/new/hooks.rs
@@ -2,13 +2,13 @@ use crate::prompt::create_fuzzy_selector_callback;
 use mdvault_core::captures::CaptureRepository;
 use mdvault_core::config::types::ResolvedConfig;
 use mdvault_core::frontmatter::{
-    parse as parse_frontmatter, serialize_with_order, Frontmatter, ParsedDocument,
+    Frontmatter, ParsedDocument, parse as parse_frontmatter, serialize_with_order,
 };
 use mdvault_core::index::IndexDb;
 use mdvault_core::macros::MacroRepository;
 use mdvault_core::paths::PathResolver;
 use mdvault_core::scripting::{
-    run_on_create_hook, HookResult, NoteContext, VaultContext,
+    HookResult, NoteContext, VaultContext, run_on_create_hook,
 };
 use mdvault_core::templates::repository::TemplateRepository;
 use mdvault_core::types::{TypeDefinition, TypeRegistry, TypedefRepository};
@@ -54,7 +54,7 @@ pub(super) fn run_on_create_hook_if_exists(
                     frontmatter: None,
                     content: None,
                     variables: None,
-                })
+                });
             }
         };
 
@@ -66,7 +66,7 @@ pub(super) fn run_on_create_hook_if_exists(
                     frontmatter: None,
                     content: None,
                     variables: None,
-                })
+                });
             }
         }
     };

--- a/crates/cli/src/cmd/new/mod.rs
+++ b/crates/cli/src/cmd/new/mod.rs
@@ -3,11 +3,11 @@ mod hooks;
 mod prompts;
 mod writer;
 
-use color_eyre::eyre::{bail, Result, WrapErr};
+use color_eyre::eyre::{Result, WrapErr, bail};
 
 use super::common::load_config;
-use crate::prompt::{CollectedVars, PromptOptions};
 use crate::NewArgs;
+use crate::prompt::{CollectedVars, PromptOptions};
 use mdvault_core::activity::ActivityLogService;
 use mdvault_core::config::types::ResolvedConfig;
 use mdvault_core::context::ContextManager;
@@ -75,11 +75,11 @@ fn inject_focus_context(cfg: &ResolvedConfig, vars: &mut HashMap<String, String>
     if vars.contains_key("project") {
         return;
     }
-    if let Ok(context_mgr) = ContextManager::load(&cfg.vault_root) {
-        if let Some(focused_project) = context_mgr.active_project() {
-            debug!("Using focused project: {}", focused_project);
-            vars.insert("project".to_string(), focused_project.to_string());
-        }
+    if let Ok(context_mgr) = ContextManager::load(&cfg.vault_root)
+        && let Some(focused_project) = context_mgr.active_project()
+    {
+        debug!("Using focused project: {}", focused_project);
+        vars.insert("project".to_string(), focused_project.to_string());
     }
 }
 
@@ -156,7 +156,7 @@ fn run_unified(cfg: &ResolvedConfig, effective_name: &str, args: &NewArgs) -> Re
 
     // 7–9. If behaviour: build CreationContext, inject focus, type prompts, sync vars
     let mut creation_ctx: Option<CreationContext> = None;
-    if let (Some(ref mut _nt), Some(ref registry)) = (&mut note_type, &type_registry) {
+    if let (Some(_nt), Some(registry)) = (&mut note_type, &type_registry) {
         let ctx_title =
             provided_vars.get("title").cloned().unwrap_or_else(|| title.clone());
         let mut ctx = CreationContext::new(effective_name, &ctx_title, cfg, registry)
@@ -307,27 +307,27 @@ fn run_unified(cfg: &ResolvedConfig, effective_name: &str, args: &NewArgs) -> Re
     }
 
     // 19. Validate before write
-    if let Some(ref typedef) = lua_typedef {
-        if let Some(ref registry) = type_registry {
-            let note_type_name = discovery::extract_note_type(&rendered)
-                .unwrap_or_else(|| typedef.name.clone());
+    if let Some(ref typedef) = lua_typedef
+        && let Some(ref registry) = type_registry
+    {
+        let note_type_name = discovery::extract_note_type(&rendered)
+            .unwrap_or_else(|| typedef.name.clone());
 
-            match writer::validate_before_write(
-                registry,
-                &note_type_name,
-                &output_path,
-                &rendered,
-            ) {
-                Ok(Some(fixed)) => rendered = fixed,
-                Ok(None) => {}
-                Err(errors) => {
-                    let errs = errors
-                        .iter()
-                        .map(|e| format!("  - {e}"))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    bail!("Validation failed:\n{errs}");
-                }
+        match writer::validate_before_write(
+            registry,
+            &note_type_name,
+            &output_path,
+            &rendered,
+        ) {
+            Ok(Some(fixed)) => rendered = fixed,
+            Ok(None) => {}
+            Err(errors) => {
+                let errs = errors
+                    .iter()
+                    .map(|e| format!("  - {e}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                bail!("Validation failed:\n{errs}");
             }
         }
     }
@@ -360,16 +360,15 @@ fn run_unified(cfg: &ResolvedConfig, effective_name: &str, args: &NewArgs) -> Re
     // 22. Print success
     println!("OK   mdv new");
     println!("type: {}", effective_name);
-    if let Some(ref ctx) = creation_ctx {
-        if let Some(ref id) = ctx
+    if let Some(ref ctx) = creation_ctx
+        && let Some(ref id) = ctx
             .core_metadata
             .task_id
             .as_ref()
             .or(ctx.core_metadata.project_id.as_ref())
             .or(ctx.core_metadata.meeting_id.as_ref())
-        {
-            println!("id:   {}", id);
-        }
+    {
+        println!("id:   {}", id);
     }
     println!("output: {}", output_path.display());
     Ok(())
@@ -451,12 +450,11 @@ fn post_write_pipeline(
     // Re-apply core_metadata after hooks
     if let Some(ctx) = creation_ctx {
         let order = lua_typedef.as_ref().and_then(|td| td.frontmatter_order.as_deref());
-        if let Ok(current) = std::fs::read_to_string(output_path) {
-            if let Ok(fixed) = ctx.core_metadata.apply_to_content(&current, order) {
-                if let Err(e) = std::fs::write(output_path, fixed) {
-                    eprintln!("Warning: failed to re-apply core metadata: {e}");
-                }
-            }
+        if let Ok(current) = std::fs::read_to_string(output_path)
+            && let Ok(fixed) = ctx.core_metadata.apply_to_content(&current, order)
+            && let Err(e) = std::fs::write(output_path, fixed)
+        {
+            eprintln!("Warning: failed to re-apply core metadata: {e}");
         }
     }
 

--- a/crates/cli/src/cmd/new/prompts.rs
+++ b/crates/cli/src/cmd/new/prompts.rs
@@ -1,7 +1,7 @@
-use color_eyre::eyre::{bail, Result, WrapErr};
+use color_eyre::eyre::{Result, WrapErr, bail};
 
-use crate::prompt::{prompt_for_enum, prompt_for_field, CollectedVars, PromptOptions};
-use dialoguer::{theme::ColorfulTheme, Editor, FuzzySelect, Input, Select};
+use crate::prompt::{CollectedVars, PromptOptions, prompt_for_enum, prompt_for_field};
+use dialoguer::{Editor, FuzzySelect, Input, Select, theme::ColorfulTheme};
 use mdvault_core::config::types::ResolvedConfig;
 use mdvault_core::index::{IndexDb, NoteQuery, NoteType};
 use mdvault_core::paths::PathResolver;

--- a/crates/cli/src/cmd/new/writer.rs
+++ b/crates/cli/src/cmd/new/writer.rs
@@ -2,7 +2,7 @@ use mdvault_core::config::types::ResolvedConfig;
 use mdvault_core::frontmatter::parse as parse_frontmatter;
 use mdvault_core::index::{IndexBuilder, IndexDb};
 use mdvault_core::paths::PathResolver;
-use mdvault_core::types::{try_fix_note, validate_note_for_creation, TypeRegistry};
+use mdvault_core::types::{TypeRegistry, try_fix_note, validate_note_for_creation};
 use std::fs;
 use std::path::Path;
 

--- a/crates/cli/src/cmd/project.rs
+++ b/crates/cli/src/cmd/project.rs
@@ -1,14 +1,14 @@
 //! Project management commands.
 
 use chrono::{DateTime, Duration, NaiveDate, Utc};
-use color_eyre::eyre::{bail, Result, WrapErr};
+use color_eyre::eyre::{Result, WrapErr, bail};
 use mdvault_core::context::ContextManager;
 use mdvault_core::domain::task_belongs_to_project;
-use mdvault_core::domain::{services::ProjectLogService, DailyLogService};
+use mdvault_core::domain::{DailyLogService, services::ProjectLogService};
 use mdvault_core::index::{IndexDb, IndexedNote, NoteQuery, NoteType};
 use serde::Serialize;
 use std::path::Path;
-use tabled::{settings::Style, Table, Tabled};
+use tabled::{Table, Tabled, settings::Style};
 
 use mdvault_core::paths::PathResolver;
 
@@ -79,17 +79,17 @@ pub fn list(
         let (project_id, project_status, project_kind) = extract_project_info(project);
 
         // Filter by status if specified
-        if let Some(filter) = status_filter {
-            if !filter.matches(&project_status) {
-                continue;
-            }
+        if let Some(filter) = status_filter
+            && !filter.matches(&project_status)
+        {
+            continue;
         }
 
         // Filter by kind if specified
-        if let Some(filter) = kind_filter {
-            if project_kind != filter.as_str() {
-                continue;
-            }
+        if let Some(filter) = kind_filter
+            && project_kind != filter.as_str()
+        {
+            continue;
         }
 
         let title = if project.title.is_empty() {
@@ -552,27 +552,27 @@ fn calculate_project_progress(
     let mut recent_completions: Vec<RecentCompletion> = Vec::new();
 
     for task in &project_tasks {
-        if let Some(completed_at) = get_completed_at(task) {
-            if completed_at >= seven_days_ago {
-                let days_ago = (now - completed_at).num_days();
-                let task_id = get_task_id(task).unwrap_or_else(|| "-".to_string());
-                let title = if task.title.is_empty() {
-                    task.path
-                        .file_stem()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("Untitled")
-                        .to_string()
-                } else {
-                    task.title.clone()
-                };
+        if let Some(completed_at) = get_completed_at(task)
+            && completed_at >= seven_days_ago
+        {
+            let days_ago = (now - completed_at).num_days();
+            let task_id = get_task_id(task).unwrap_or_else(|| "-".to_string());
+            let title = if task.title.is_empty() {
+                task.path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("Untitled")
+                    .to_string()
+            } else {
+                task.title.clone()
+            };
 
-                recent_completions.push(RecentCompletion {
-                    id: task_id,
-                    title,
-                    completed_at: completed_at.format("%Y-%m-%d").to_string(),
-                    days_ago,
-                });
-            }
+            recent_completions.push(RecentCompletion {
+                id: task_id,
+                title,
+                completed_at: completed_at.format("%Y-%m-%d").to_string(),
+                days_ago,
+            });
         }
     }
 
@@ -828,14 +828,12 @@ pub fn archive(
     let _ = ProjectLogService::log_entry(&project_file_abs, &archive_msg);
 
     // 4. Clear focus if this project is currently focused
-    if let Ok(mut mgr) = ContextManager::load(&cfg.vault_root) {
-        if let Some(focused) = mgr.active_project() {
-            if focused.eq_ignore_ascii_case(&project_folder)
-                || focused.eq_ignore_ascii_case(&project_id)
-            {
-                let _ = mgr.clear_focus();
-            }
-        }
+    if let Ok(mut mgr) = ContextManager::load(&cfg.vault_root)
+        && let Some(focused) = mgr.active_project()
+        && (focused.eq_ignore_ascii_case(&project_folder)
+            || focused.eq_ignore_ascii_case(&project_id))
+    {
+        let _ = mgr.clear_focus();
     }
 
     // 5. Move files from Projects/{slug}/ to Projects/_archive/{slug}/

--- a/crates/cli/src/cmd/rename.rs
+++ b/crates/cli/src/cmd/rename.rs
@@ -7,7 +7,7 @@ use super::common::{load_config, open_index};
 use color_eyre::eyre::Result;
 use mdvault_core::activity::ActivityLogService;
 use mdvault_core::rename::{
-    execute_rename, generate_preview, FileChange, RenameError, RenamePreview,
+    FileChange, RenameError, RenamePreview, execute_rename, generate_preview,
 };
 
 use crate::RenameArgs;

--- a/crates/cli/src/cmd/report.rs
+++ b/crates/cli/src/cmd/report.rs
@@ -2,13 +2,13 @@
 
 use super::common::{load_config, open_index};
 use chrono::{Datelike, Duration, Local, NaiveDate, Utc};
-use color_eyre::eyre::{bail, Result, WrapErr};
+use color_eyre::eyre::{Result, WrapErr, bail};
 use mdvault_core::index::{IndexDb, IndexedNote, NoteQuery};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use tabled::{settings::Style, Table, Tabled};
+use tabled::{Table, Tabled, settings::Style};
 
 /// Report data for JSON output.
 #[derive(Serialize)]
@@ -1084,12 +1084,11 @@ fn get_note_date(note: &IndexedNote) -> Option<NaiveDate> {
 /// Get project from task frontmatter or path.
 fn get_task_project(note: &IndexedNote) -> Option<String> {
     // Try frontmatter first
-    if let Some(fm_json) = &note.frontmatter_json {
-        if let Ok(fm) = serde_json::from_str::<serde_json::Value>(fm_json) {
-            if let Some(project) = fm.get("project").and_then(|v| v.as_str()) {
-                return Some(project.to_string());
-            }
-        }
+    if let Some(fm_json) = &note.frontmatter_json
+        && let Ok(fm) = serde_json::from_str::<serde_json::Value>(fm_json)
+        && let Some(project) = fm.get("project").and_then(|v| v.as_str())
+    {
+        return Some(project.to_string());
     }
 
     // Try to extract from path (Projects/{project}/Tasks/...)

--- a/crates/cli/src/cmd/task.rs
+++ b/crates/cli/src/cmd/task.rs
@@ -1,14 +1,14 @@
 //! Task management commands.
 
-use color_eyre::eyre::{bail, Result, WrapErr};
+use color_eyre::eyre::{Result, WrapErr, bail};
 use mdvault_core::activity::ActivityLogService;
 use mdvault_core::domain::{
-    find_project_file, services::ProjectLogService, DailyLogService,
+    DailyLogService, find_project_file, services::ProjectLogService,
 };
 use mdvault_core::index::{IndexBuilder, IndexDb, IndexedNote, NoteQuery, NoteType};
 use mdvault_core::paths::PathResolver;
 use std::path::Path;
-use tabled::{settings::Style, Table, Tabled};
+use tabled::{Table, Tabled, settings::Style};
 
 use super::common::{load_config, open_index};
 use crate::StatusFilter;
@@ -53,20 +53,20 @@ pub fn list(
         let path_str = task.path.to_string_lossy();
 
         // Filter by project if specified
-        if let Some(proj) = project_filter {
-            if !path_str.contains(proj) {
-                continue;
-            }
+        if let Some(proj) = project_filter
+            && !path_str.contains(proj)
+        {
+            continue;
         }
 
         // Get task info from frontmatter
         let (task_id, task_status, project) = extract_task_info(task);
 
         // Filter by status if specified
-        if let Some(filter) = status_filter {
-            if !filter.matches(&task_status) {
-                continue;
-            }
+        if let Some(filter) = status_filter
+            && !filter.matches(&task_status)
+        {
+            continue;
         }
 
         let title = if task.title.is_empty() {
@@ -293,11 +293,11 @@ pub fn done(
     );
 
     // Log to parent project note
-    if let Some(ref project) = project_name {
-        if let Ok(project_file) = find_project_file(&cfg, project) {
-            let msg = format!("Completed task [[{}]]: {}", task_id, safe_title);
-            let _ = ProjectLogService::log_entry(&project_file, &msg);
-        }
+    if let Some(ref project) = project_name
+        && let Ok(project_file) = find_project_file(&cfg, project)
+    {
+        let msg = format!("Completed task [[{}]]: {}", task_id, safe_title);
+        let _ = ProjectLogService::log_entry(&project_file, &msg);
     }
 
     println!("OK   mdv task done");
@@ -437,11 +437,11 @@ pub fn cancel(
     );
 
     // Log to parent project note
-    if let Some(ref project) = project_name {
-        if let Ok(project_file) = find_project_file(&cfg, project) {
-            let msg = format!("Cancelled task [[{}]]: {}", task_id, safe_title);
-            let _ = ProjectLogService::log_entry(&project_file, &msg);
-        }
+    if let Some(ref project) = project_name
+        && let Ok(project_file) = find_project_file(&cfg, project)
+    {
+        let msg = format!("Cancelled task [[{}]]: {}", task_id, safe_title);
+        let _ = ProjectLogService::log_entry(&project_file, &msg);
     }
 
     println!("OK   mdv task cancel");
@@ -572,7 +572,9 @@ mod tests {
     fn nested_wikilinks() {
         // The exact case from the bug report
         assert_eq!(
-            strip_wikilinks("Read [[Zettel/Literature/survey-llm-architectures-2024|Survey of Different Large Language Model Architectures]]"),
+            strip_wikilinks(
+                "Read [[Zettel/Literature/survey-llm-architectures-2024|Survey of Different Large Language Model Architectures]]"
+            ),
             "Read Survey of Different Large Language Model Architectures"
         );
     }

--- a/crates/cli/src/cmd/today.rs
+++ b/crates/cli/src/cmd/today.rs
@@ -2,11 +2,11 @@
 
 use super::common::{load_config, open_index};
 use chrono::{Local, NaiveDate, Timelike};
-use color_eyre::eyre::{bail, Result};
+use color_eyre::eyre::{Result, bail};
 use mdvault_core::index::{IndexDb, IndexedNote, NoteQuery};
 use serde::Serialize;
 use std::path::Path;
-use tabled::{settings::Style, Table, Tabled};
+use tabled::{Table, Tabled, settings::Style};
 
 use crate::TodayArgs;
 
@@ -65,11 +65,7 @@ pub fn run(config: Option<&Path>, profile: Option<&str>, args: TodayArgs) -> Res
         "review"
     } else {
         // Auto-select based on time: before noon = plan, after noon = review
-        if Local::now().hour() < 12 {
-            "plan"
-        } else {
-            "review"
-        }
+        if Local::now().hour() < 12 { "plan" } else { "review" }
     };
 
     let today = Local::now().date_naive();
@@ -161,11 +157,11 @@ fn gather_dashboard_data(
         let info = extract_task_info(task);
 
         // Check if completed today
-        if let Some(completed_at) = get_completed_at(task) {
-            if completed_at == today {
-                completed_today.push(info);
-                continue;
-            }
+        if let Some(completed_at) = get_completed_at(task)
+            && completed_at == today
+        {
+            completed_today.push(info);
+            continue;
         }
 
         // Check status
@@ -175,23 +171,21 @@ fn gather_dashboard_data(
             }
             "in-progress" => {
                 // Check if overdue
-                if let Some(ref due) = info.due_date {
-                    if let Ok(due_date) = NaiveDate::parse_from_str(due, "%Y-%m-%d") {
-                        if due_date < today {
-                            overdue_tasks.push(info.clone());
-                        }
-                    }
+                if let Some(ref due) = info.due_date
+                    && let Ok(due_date) = NaiveDate::parse_from_str(due, "%Y-%m-%d")
+                    && due_date < today
+                {
+                    overdue_tasks.push(info.clone());
                 }
                 in_progress_tasks.push(info);
             }
             _ => {
                 // Check if overdue for todo/pending/other non-done statuses
-                if let Some(ref due) = info.due_date {
-                    if let Ok(due_date) = NaiveDate::parse_from_str(due, "%Y-%m-%d") {
-                        if due_date < today {
-                            overdue_tasks.push(info.clone());
-                        }
-                    }
+                if let Some(ref due) = info.due_date
+                    && let Ok(due_date) = NaiveDate::parse_from_str(due, "%Y-%m-%d")
+                    && due_date < today
+                {
+                    overdue_tasks.push(info.clone());
                 }
                 if info.status != "blocked" {
                     pending_tasks.push(info);
@@ -511,10 +505,10 @@ fn extract_task_info(note: &IndexedNote) -> TaskInfo {
             let path_str = note.path.to_string_lossy();
             if path_str.contains("Projects/") {
                 let parts: Vec<&str> = path_str.split("Projects/").collect();
-                if parts.len() > 1 {
-                    if let Some(project_name) = parts[1].split('/').next() {
-                        return project_name.to_string();
-                    }
+                if parts.len() > 1
+                    && let Some(project_name) = parts[1].split('/').next()
+                {
+                    return project_name.to_string();
                 }
             }
             "INB".to_string()

--- a/crates/cli/src/cmd/validate.rs
+++ b/crates/cli/src/cmd/validate.rs
@@ -2,13 +2,13 @@
 
 use std::path::Path;
 
-use color_eyre::eyre::{bail, Result, WrapErr};
+use color_eyre::eyre::{Result, WrapErr, bail};
 use mdvault_core::frontmatter::parse as parse_frontmatter;
 use mdvault_core::index::IndexDb;
 use mdvault_core::paths::PathResolver;
 use mdvault_core::types::{
-    add_link_integrity_warnings, apply_fixes, try_fix_note, validate_note, TypeRegistry,
-    TypedefRepository, ValidationResult,
+    TypeRegistry, TypedefRepository, ValidationResult, add_link_integrity_warnings,
+    apply_fixes, try_fix_note, validate_note,
 };
 
 use super::common::load_config;
@@ -168,10 +168,10 @@ pub fn run(
         };
 
         // Check link integrity if requested and index is available
-        if args.check_links {
-            if let Some(ref db) = index_db {
-                add_link_integrity_warnings(&mut result, db, &note.relative_path);
-            }
+        if args.check_links
+            && let Some(ref db) = index_db
+        {
+            add_link_integrity_warnings(&mut result, db, &note.relative_path);
         }
 
         // Determine if note is valid (errors only, warnings don't count)
@@ -340,7 +340,7 @@ fn print_results_table(
         // Show remaining errors
         for error in &result.errors {
             // Skip errors that were fixed
-            if let Some(ref applied) = fixes {
+            if let Some(applied) = &fixes {
                 let error_str = error.to_string();
                 if applied
                     .iter()

--- a/crates/cli/src/completions.rs
+++ b/crates/cli/src/completions.rs
@@ -45,15 +45,15 @@ pub fn complete_types(current: &OsStr) -> Vec<CompletionCandidate> {
             }
             None => TypedefRepository::new(&cfg.typedefs_dir),
         };
-        if let Ok(typedef_repo) = typedef_result {
-            if let Ok(registry) = TypeRegistry::from_repository(&typedef_repo) {
-                for type_name in registry.list_custom_types() {
-                    if type_name.starts_with(current_str) {
-                        completions.push(
-                            CompletionCandidate::new(type_name)
-                                .help(Some("Custom type".into())),
-                        );
-                    }
+        if let Ok(typedef_repo) = typedef_result
+            && let Ok(registry) = TypeRegistry::from_repository(&typedef_repo)
+        {
+            for type_name in registry.list_custom_types() {
+                if type_name.starts_with(current_str) {
+                    completions.push(
+                        CompletionCandidate::new(type_name)
+                            .help(Some("Custom type".into())),
+                    );
                 }
             }
         }
@@ -67,12 +67,12 @@ pub fn complete_templates(current: &OsStr) -> Vec<CompletionCandidate> {
     let mut completions = vec![];
     let current_str = current.to_str().unwrap_or("");
 
-    if let Some(cfg) = load_config() {
-        if let Ok(repo) = TemplateRepository::new(&cfg.templates_dir) {
-            for info in repo.list_all() {
-                if info.logical_name.starts_with(current_str) {
-                    completions.push(CompletionCandidate::new(&info.logical_name));
-                }
+    if let Some(cfg) = load_config()
+        && let Ok(repo) = TemplateRepository::new(&cfg.templates_dir)
+    {
+        for info in repo.list_all() {
+            if info.logical_name.starts_with(current_str) {
+                completions.push(CompletionCandidate::new(&info.logical_name));
             }
         }
     }
@@ -85,12 +85,12 @@ pub fn complete_captures(current: &OsStr) -> Vec<CompletionCandidate> {
     let mut completions = vec![];
     let current_str = current.to_str().unwrap_or("");
 
-    if let Some(cfg) = load_config() {
-        if let Ok(repo) = CaptureRepository::new(&cfg.captures_dir) {
-            for info in repo.list_all() {
-                if info.logical_name.starts_with(current_str) {
-                    completions.push(CompletionCandidate::new(&info.logical_name));
-                }
+    if let Some(cfg) = load_config()
+        && let Ok(repo) = CaptureRepository::new(&cfg.captures_dir)
+    {
+        for info in repo.list_all() {
+            if info.logical_name.starts_with(current_str) {
+                completions.push(CompletionCandidate::new(&info.logical_name));
             }
         }
     }
@@ -103,12 +103,12 @@ pub fn complete_macros(current: &OsStr) -> Vec<CompletionCandidate> {
     let mut completions = vec![];
     let current_str = current.to_str().unwrap_or("");
 
-    if let Some(cfg) = load_config() {
-        if let Ok(repo) = MacroRepository::new(&cfg.macros_dir) {
-            for info in repo.list_all() {
-                if info.logical_name.starts_with(current_str) {
-                    completions.push(CompletionCandidate::new(&info.logical_name));
-                }
+    if let Some(cfg) = load_config()
+        && let Ok(repo) = MacroRepository::new(&cfg.macros_dir)
+    {
+        for info in repo.list_all() {
+            if info.logical_name.starts_with(current_str) {
+                completions.push(CompletionCandidate::new(&info.logical_name));
             }
         }
     }

--- a/crates/cli/src/prompt.rs
+++ b/crates/cli/src/prompt.rs
@@ -6,11 +6,11 @@
 //! - Handle defaults and required/optional status
 //! - Support batch mode (non-interactive) for CI/scripting
 
-use dialoguer::{theme::ColorfulTheme, FuzzySelect, Input, Select};
+use dialoguer::{FuzzySelect, Input, Select, theme::ColorfulTheme};
 use mdvault_core::scripting::{SelectorCallback, SelectorItem, SelectorOptions};
 use mdvault_core::templates::engine::RenderContext;
 use mdvault_core::vars::{
-    collect_all_variables, try_evaluate_date_expr, VarSpec, VarsMap,
+    VarSpec, VarsMap, collect_all_variables, try_evaluate_date_expr,
 };
 use std::collections::HashMap;
 use std::io::{self, IsTerminal};
@@ -51,7 +51,10 @@ impl std::fmt::Display for PromptError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PromptError::MissingRequired(name) => {
-                write!(f, "missing required variable: {name}\n  Hint: use --var {name}=\"...\" or remove --batch")
+                write!(
+                    f,
+                    "missing required variable: {name}\n  Hint: use --var {name}=\"...\" or remove --batch"
+                )
             }
             PromptError::Io(e) => write!(f, "IO error: {e}"),
             PromptError::Cancelled => write!(f, "input cancelled by user"),
@@ -315,20 +318,6 @@ pub fn prompt_for_enum(
     }
 }
 
-/// Parse --var arguments into a HashMap.
-///
-/// Expected format: `key=value`
-#[allow(dead_code)]
-pub fn parse_var_args(args: &[String]) -> HashMap<String, String> {
-    let mut map = HashMap::new();
-    for arg in args {
-        if let Some((key, value)) = arg.split_once('=') {
-            map.insert(key.to_string(), value.to_string());
-        }
-    }
-    map
-}
-
 /// Create a selector callback that uses dialoguer's FuzzySelect.
 ///
 /// This callback is passed to VaultContext to enable `mdv.selector()` in Lua scripts.
@@ -375,19 +364,6 @@ pub fn create_fuzzy_selector_callback() -> SelectorCallback {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_parse_var_args() {
-        let args = vec![
-            "title=Hello".to_string(),
-            "author=World".to_string(),
-            "empty=".to_string(),
-        ];
-        let map = parse_var_args(&args);
-        assert_eq!(map.get("title"), Some(&"Hello".to_string()));
-        assert_eq!(map.get("author"), Some(&"World".to_string()));
-        assert_eq!(map.get("empty"), Some(&String::new()));
-    }
 
     #[test]
     fn test_resolve_default_static() {

--- a/crates/cli/src/tui/actions.rs
+++ b/crates/cli/src/tui/actions.rs
@@ -11,7 +11,7 @@ use mdvault_core::captures::{CaptureRepository, CaptureSpec};
 use mdvault_core::config::types::ResolvedConfig;
 use mdvault_core::frontmatter::{apply_ops, parse, serialize};
 use mdvault_core::macros::{
-    run_macro, MacroRepository, RunContext, RunOptions, StepExecutor,
+    MacroRepository, RunContext, RunOptions, StepExecutor, run_macro,
 };
 use mdvault_core::markdown_ast::{MarkdownAstError, MarkdownEditor, SectionMatch};
 use mdvault_core::templates::discovery::TemplateInfo;
@@ -235,11 +235,7 @@ fn render_string(template: &str, ctx: &HashMap<String, String>) -> String {
 
 fn resolve_target_path(vault_root: &Path, target: &str) -> std::path::PathBuf {
     let path = std::path::Path::new(target);
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        vault_root.join(path)
-    }
+    if path.is_absolute() { path.to_path_buf() } else { vault_root.join(path) }
 }
 
 /// Execute a macro workflow.
@@ -444,10 +440,10 @@ pub fn execute_macro(
 
     if result.success {
         let mut msg = format!("Completed {} steps", result.step_results.len());
-        if let Some(last) = result.step_results.last() {
-            if let Some(path) = &last.output_path {
-                msg.push_str(&format!(" → {}", path.display()));
-            }
+        if let Some(last) = result.step_results.last()
+            && let Some(path) = &last.output_path
+        {
+            msg.push_str(&format!(" → {}", path.display()));
         }
         Ok(msg)
     } else {

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use mdvault_core::captures::CaptureInfo;
 use mdvault_core::config::types::ResolvedConfig;
-use mdvault_core::macros::{requires_trust, MacroInfo};
+use mdvault_core::macros::{MacroInfo, requires_trust};
 use mdvault_core::templates::discovery::TemplateInfo;
 use mdvault_core::templates::engine::build_minimal_context;
 use mdvault_core::templates::repository::TemplateRepository;
@@ -379,13 +379,13 @@ impl App {
         }
 
         // Check if template has output path in frontmatter
-        if let Some(ref fm) = loaded.frontmatter {
-            if let Some(ref output) = fm.output {
-                let rendered = render_string(output, &ctx)
-                    .map_err(|e| format!("Failed to render output path: {e}"))?;
-                let path = self.config.vault_root.join(&rendered);
-                return Ok(Some(path));
-            }
+        if let Some(ref fm) = loaded.frontmatter
+            && let Some(ref output) = fm.output
+        {
+            let rendered = render_string(output, &ctx)
+                .map_err(|e| format!("Failed to render output path: {e}"))?;
+            let path = self.config.vault_root.join(&rendered);
+            return Ok(Some(path));
         }
 
         Ok(None)

--- a/crates/cli/src/tui/dashboard/mod.rs
+++ b/crates/cli/src/tui/dashboard/mod.rs
@@ -14,10 +14,10 @@ use std::time::Duration;
 
 use color_eyre::eyre::Result;
 use crossterm::{
-    event::{poll, read, Event},
+    event::{Event, poll, read},
     execute,
     terminal::{
-        disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+        EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
     },
 };
 use ratatui::prelude::*;
@@ -25,7 +25,7 @@ use ratatui::prelude::*;
 use mdvault_core::config::loader::ConfigLoader;
 use mdvault_core::index::IndexDb;
 use mdvault_core::paths::PathResolver;
-use mdvault_core::report::{build_dashboard, DashboardOptions};
+use mdvault_core::report::{DashboardOptions, build_dashboard};
 
 use app::DashboardApp;
 use event::map_key_event;
@@ -100,12 +100,11 @@ fn run_app(
     loop {
         terminal.draw(|frame| ui::draw(frame, &app))?;
 
-        if poll(Duration::from_millis(100))? {
-            if let Event::Key(key) = read()? {
-                if let Some(msg) = map_key_event(&app, key) {
-                    app.update(msg);
-                }
-            }
+        if poll(Duration::from_millis(100))?
+            && let Event::Key(key) = read()?
+            && let Some(msg) = map_key_event(&app, key)
+        {
+            app.update(msg);
         }
 
         if app.should_quit {

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -12,10 +12,10 @@ use std::time::Duration;
 
 use color_eyre::eyre::Result;
 use crossterm::{
-    event::{poll, read, Event},
+    event::{Event, poll, read},
     execute,
     terminal::{
-        disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+        EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
     },
 };
 use ratatui::prelude::*;
@@ -108,13 +108,13 @@ fn run_app(
         terminal.draw(|frame| ui::draw(frame, &app))?;
 
         // 2. Poll for events (with timeout for responsiveness)
-        if poll(Duration::from_millis(100))? {
-            if let Event::Key(key) = read()? {
-                // 3. Map key event to message
-                if let Some(msg) = map_key_event(&app, key) {
-                    // 4. Process message
-                    app.update(msg);
-                }
+        if poll(Duration::from_millis(100))?
+            && let Event::Key(key) = read()?
+        {
+            // 3. Map key event to message
+            if let Some(msg) = map_key_event(&app, key) {
+                // 4. Process message
+                app.update(msg);
             }
         }
 

--- a/crates/cli/tests/new_custom_typedef.rs
+++ b/crates/cli/tests/new_custom_typedef.rs
@@ -129,7 +129,10 @@ fn new_custom_type_validation_fails() {
 
     // Create template that produces invalid content (missing DRAFT marker)
     let template_path = templates_dir.join("report.md");
-    write(&template_path, "---\ntype: report\ntitle: {{title}}\nstatus: draft\n---\n# Report: {{title}}\n\nSome content.");
+    write(
+        &template_path,
+        "---\ntype: report\ntitle: {{title}}\nstatus: draft\n---\n# Report: {{title}}\n\nSome content.",
+    );
 
     let toml = format!(
         "version = 1\n\

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdvault-core"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "Core library for mdvault - markdown vault management"
 license = "MIT"

--- a/crates/core/src/rename/detector.rs
+++ b/crates/core/src/rename/detector.rs
@@ -9,7 +9,7 @@ use std::sync::LazyLock;
 use regex::Regex;
 
 use crate::frontmatter;
-use crate::rename::types::{Reference, ReferenceType, RenameError};
+use crate::rename::types::{Reference, ReferenceType};
 
 // Regex patterns for reference detection
 static WIKILINK_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -427,20 +427,6 @@ fn find_frontmatter_list_item(
     }
 
     None
-}
-
-/// Read a file and find all references to a target note.
-#[allow(dead_code)]
-pub fn find_references_in_file(
-    source_path: &Path,
-    target_path: &Path,
-    vault_root: &Path,
-) -> Result<Vec<Reference>, RenameError> {
-    let content = std::fs::read_to_string(source_path).map_err(|e| {
-        RenameError::ReadError { path: source_path.to_path_buf(), source: e }
-    })?;
-
-    Ok(find_references_in_content(&content, source_path, target_path, vault_root))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Phase 4 (final) of the [CLI refactoring plan](Projects/markdownvault-development/resources/cli-refactoring-plan.md) — cleanup and dead code audit.

### Changes

- **Edition alignment**: CLI crate upgraded from edition 2021 → 2024 (core was already 2024)
- **Dead code removed**: `find_references_in_file()` (never called), `parse_var_args()` (never called)
- **35 collapsible-if patterns** fixed for edition 2024 let-chain support
- **3 `ref` pattern warnings** fixed for edition 2024 stricter matching
- Net -61 lines across 31 files

### What was kept

- `CollectedVars.prompted`/`.defaulted` — used in tests, useful for future diagnostics
- `compute_relative_path()` — tested, planned for future rename features
- `LuaEngine.config` — field is accessed in constructors for memory limits

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all --all-features` (715 pass, 0 fail)